### PR TITLE
Enable to make console.bat

### DIFF
--- a/src/assembly/dist.xml
+++ b/src/assembly/dist.xml
@@ -11,6 +11,10 @@
       <outputDirectory>bin</outputDirectory>
     </file>
     <file>
+      <source>bin/console.bat</source>
+      <outputDirectory>bin</outputDirectory>
+    </file>
+    <file>
       <source>VERSION</source>
     </file>
     <file>


### PR DESCRIPTION
clear that console.bat was not deployed. 
