### PR TITLE
Enable to refresh console after close job edit sub-window in IE.

### DIFF
--- a/src/cljs/job_streamer/console/components/job_detail.cljs
+++ b/src/cljs/job_streamer/console/components/job_detail.cljs
@@ -448,7 +448,7 @@
           {:type "button"
            :on-click (fn [e]
                        (let [w (js/window.open (str "/" app-name "/job/" name "/edit") name "width=1200,height=800")]
-                         (.addEventListener w "unload" (fn [] (js/setTimeout (fn [] (put! refresh-job-ch true))) 10))))}
+                         (js/setTimeout (fn [] (.addEventListener w "unload" (fn [] (js/setTimeout (fn [] (put! refresh-job-ch true))) 10))) 10)))}
           "Edit"]]]]
       [:div {:style {:height "200px"
                      :width "100%"

--- a/src/cljs/job_streamer/console/components/jobs.cljs
+++ b/src/cljs/job_streamer/console/components/jobs.cljs
@@ -175,7 +175,7 @@
                  {:type "button"
                   :on-click (fn [e]
                               (let [w (js/window.open (str "/" app-name "/jobs/new") "New" "width=1200,height=800")]
-                                (.addEventListener w "unload" (fn [] (js/setTimeout (fn [] (put! jobs-view-channel [:refresh-jobs true]))) 10))))}
+                                (js/setTimeout (fn [] (.addEventListener w "unload" (fn [] (js/setTimeout (fn [] (put! jobs-view-channel [:refresh-jobs true]))) 10))) 10)))}
                  [:i.plus.icon] "Create the first job"]]]]]]]
        [:div.ui.grid
         [:div.ui.two.column.row
@@ -184,7 +184,7 @@
            {:type "button"
             :on-click (fn [e]
                         (let [w (js/window.open (str "/" app-name "/jobs/new") "New" "width=1200,height=800")]
-                          (.addEventListener w "unload" (fn [] (js/setTimeout (fn [] (put! jobs-view-channel [:refresh-jobs true]))) 10))))}
+                          (js/setTimeout (fn [] (.addEventListener w "unload" (fn [] (js/setTimeout (fn [] (put! jobs-view-channel [:refresh-jobs true]))) 10))) 10)))}
            [:i.plus.icon] "New"]]
          [:div.ui.right.aligned.column
           [:button.ui.circular.basic.orange.icon.button


### PR DESCRIPTION
Changed to wait 10ms when it calls addEventListener of subwindow. 
Because IE has delay for binding window object after window.open.